### PR TITLE
Fix Markdown formatting for GitHub web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-#An Unexpected Surprise<img width="25%" align="right" src="http://i.imgur.com/wfamleY.jpg">
+# An Unexpected Surprise
+<img width="25%" align="right" src="http://i.imgur.com/wfamleY.jpg">
 In 1993, the game _Rebel Assault_ (v1.2) from LucasArts was released for MS-DOS on CD. It contained a handful of development content that wasn't intended to be shipped, including _Deluxe Paint II Enhanced_.
 
 I'll be writing up more on this, but for now, here is the archive. It is kept here for historical preservation.
-<hr/>
-##The \ALIASES Directory
+
+## The \ALIASES Directory
 |Filename|My Best Guess|
 |--------|---|
 |`ALIASES/CDON.BAT`|Empty
@@ -29,9 +30,7 @@ These seem to be DOS aliases used with a LOAD command. (See SDK.BAT for an examp
 |`ALIASES/MSC6.NRK`| Microsoft C 6.0?
 |`ALIASES/MAIN.NRK`| Generic aliases
 
-<hr/>
-##The \UTIL Directory
-
+## The \UTIL Directory
 |Filename|My Best Guess or Command Output|
 |--------|---|
 |`UTIL/2B.BAT`|Copies files to the B: drive
@@ -70,16 +69,16 @@ These seem to be DOS aliases used with a LOAD command. (See SDK.BAT for an examp
 |`UTIL/X.BAT`|Older version of `NETON.BAT`?
 |`UTIL/X32FIX.EXE`|`FlashTek X-32 Fixup Utility` - Watcom util
 
-##Notable Tools
-###Deluxe Paint II Enhanced
+## Notable Tools
+### Deluxe Paint II Enhanced
 Barebones copies of Electronic Arts' famous pixel art application were present. Two versions, actually. Versions 2.1 and 2.3.
 
 <img src="http://i.imgur.com/G2YlHLu.jpg" width="49%" style="float:left"/>
 <img src="http://i.imgur.com/zqZWWbK.jpg" width="49%" style="float:right"/>
 <div style="clear:both"></div>
 
-###DK.EXE
-This, from what I recall, is an in-house LucasArts image 'Swiss Army Knife' tool. Among it's powers: it could reduce the number of colors in an image, using dithering, or adapt an image to fit an existing palette.
+### DK.EXE
+This, from what I recall, is an in-house LucasArts image 'Swiss Army Knife' tool. Among its powers: it could reduce the number of colors in an image, using dithering, or adapt an image to fit an existing palette.
 
 <img src="http://i.imgur.com/WpmUnd3.jpg" width="49%" style="float:left"/>
 <img src="http://i.imgur.com/QIrudo4.jpg" width="49%" style="float:right"/>


### PR DESCRIPTION
GitHub's markdown parser is really picky and didn't display the readme properly. I just touched it up.